### PR TITLE
Add 2.9.2 release of qscintilla

### DIFF
--- a/qscintilla/qscintilla.2016-04-18.manifest
+++ b/qscintilla/qscintilla.2016-04-18.manifest
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://inqlude.org/schema/release-manifest-v1#",
+  "name": "qscintilla",
+  "version": "2.9.2",
+  "release_date": "2016-04-18",
+  "summary": "Qt port of Scintilla C++ editor control",
+  "urls": {
+    "homepage": "https://riverbankcomputing.com/software/qscintilla/intro",
+    "download": "https://riverbankcomputing.com/software/qscintilla/download",
+    "api_docs": "http://pyqt.sourceforge.net/Docs/QScintilla2/index.html",
+    "announcement": "https://www.riverbankcomputing.com/news/qscintilla-292"
+  },
+  "licenses": [
+    "GPLv2",
+    "GPLv3",
+    "Commercial"
+  ],
+  "description": "QScintilla is a port to Qt of Neil Hodgson's Scintilla C++ editor control.\n\nAs well as features found in standard text editing components, QScintilla includes features especially useful when editing and debugging source code. These include support for syntax styling, error indicators, code completion and call tips. The selection margin can contain markers like those used in debuggers to indicate breakpoints and the current line. Styling choices are more open than with many editors, allowing the use of proportional fonts, bold and italics, multiple foreground and background colours and multiple fonts. Moreover it supports recordable macros, multiple views and printing.",
+  "maturity": "stable",
+  "authors": [
+    "Riverbank Computing Limited <info@riverbankcomputing.com>"
+  ],
+  "platforms": [
+    "Linux",
+    "Windows",
+    "OS X",
+    "iOS",
+    "Android"
+  ],
+  "packages": {
+    "source": "https://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.9.2/QScintilla_gpl-2.9.2.tar.gz/download"    
+  }
+}


### PR DESCRIPTION
Add version and release date.
Add link to the release announcement page.
Improve description.
Add platform support for 'OS X', 'Android' and 'iOS'.
Add source package for 2.9.2 release.