### PR TITLE
Add 0.1.1 release of adctl

### DIFF
--- a/adctl/adctl.2016-04-03.manifest
+++ b/adctl/adctl.2016-04-03.manifest
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://inqlude.org/schema/release-manifest-v1#",
+  "name": "adctl",
+  "display_name": "AdCtl",
+  "release_date": "2016-04-03",
+  "version": "0.1.1",
+  "summary": "Google Play Auth, Achives and Ratings, AdMob, and Analytics for Qt/QML on Android/iOS",
+  "urls": {
+    "homepage": "https://github.com/kafeg/adctl",
+    "vcs": "https://github.com/kafeg/adctl.git",
+    "download": "https://github.com/kafeg/adctl/releases",
+    "mailing_list": "https://github.com/kafeg/adctl/issues",
+    "custom": {
+        "Wiki": "https://github.com/kafeg/adctl/wiki"
+    }
+  },
+  "licenses": [
+    "Modified BSD"
+  ],
+  "description": "AdCtl - library adds support of Google Analytics, Google AdMob, Google Play Services, StartAd.mobi, Google Cloud Messaging, and online purchase of Stripe.com and Cloudpayments.ru for your Qt/C++ or Qt Quick/QML project.\n\n",
+  "authors": [
+    "Vitaliy Petrov"
+  ],
+  "maturity": "alpha",
+  "platforms": [
+    "Android", "iOS"
+  ],
+  "packages": {
+      "source": "https://github.com/kafeg/adctl/archive/qpm/0.1.1.tar.gz"
+  },
+  "group": "mobile"
+}


### PR DESCRIPTION
* Change from generic to release manifest.
* Add new version and release date.
* Add links for 'download' and 'Wiki'.
* Add maturity level.
* Add source package for 0.1.1 release.

Supersedes: #97