### PR TITLE
Add topics to manifests

### DIFF
--- a/adctl/adctl.2016-04-03.manifest
+++ b/adctl/adctl.2016-04-03.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-04-03",
   "version": "0.1.1",
   "summary": "Google Play Auth, Achives and Ratings, AdMob, and Analytics for Qt/QML on Android/iOS",
+  "topics": [
+    "Mobile",
+    "QML"
+  ],
   "urls": {
     "homepage": "https://github.com/kafeg/adctl",
     "vcs": "https://github.com/kafeg/adctl.git",

--- a/attica/attica.2016-05-15.manifest
+++ b/attica/attica.2016-05-15.manifest
@@ -4,6 +4,9 @@
   "release_date": "2016-05-15",
   "version": "5.22.0",
   "summary": "Open Collaboration Service client library",
+  "topics": [
+    "API"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/kdesupport/attica",
     "tutorial": "http://techbase.kde.org/Development/Tutorials/Collaboration/Attica/Introduction",

--- a/avahi-qt/avahi-qt.2016-02-16.manifest
+++ b/avahi-qt/avahi-qt.2016-02-16.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-02-16",
   "version": "0.6.32",
   "summary": "Qt4 Bindings for avahi, the D-BUS Service for Zeroconf and Bonjour",
+  "topics": [
+    "Bindings",
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://www.avahi.org/",
     "vcs": "https://github.com/lathiat/avahi",

--- a/baloo/baloo.2016-06-13.manifest
+++ b/baloo/baloo.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Baloo is a file indexing and searching framework",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/baloo/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/bluez-qt/bluez-qt.2016-06-13.manifest
+++ b/bluez-qt/bluez-qt.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Qt wrapper for BlueZ 5 DBus API",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/bluez-qt/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/breeze-icons/breeze-icons.2016-06-13.manifest
+++ b/breeze-icons/breeze-icons.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Breeze icon theme",
+  "topics": [
+    "Artwork"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/breeze-icons/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/ctk/ctk.manifest
+++ b/ctk/ctk.manifest
@@ -2,6 +2,11 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "ctk",
   "summary": "Toolkit for biomedical image computing",
+  "topics": [
+    "Graphics",
+    "Widgets",
+    "Data"
+  ],
   "urls": {
     "homepage": "http://www.commontk.org/index.php/Main_Page",
     "vcs": "http://github.com/commontk/CTK",

--- a/cutelyst/cutelyst.2014-11-24.manifest
+++ b/cutelyst/cutelyst.2014-11-24.manifest
@@ -4,6 +4,9 @@
   "version": "0.5.0",
   "release_date": "2014-11-24",
   "summary": "A Web Framework, using the simple approach of Catalyst (Perl) framework.",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://cutelyst.org/",
     "vcs": "https://gitorious.org/cutelyst/cutelyst.git",

--- a/cutereport/cutereport.2016-01-17.manifest
+++ b/cutereport/cutereport.2016-01-17.manifest
@@ -5,6 +5,9 @@
   "version": "1.2",
   "release_date": "2016-01-17",
   "summary": "Report solution",
+  "topics": [
+    "Printing"
+  ],
   "urls": {
     "homepage": "http://cute-report.com/",
     "vcs": "",

--- a/cutetest/cutetest.manifest
+++ b/cutetest/cutetest.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "cutetest",
   "summary": "Unit testing for Qt",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://qt-project.org/forums/viewthread/14660/",
     "vcs": "https://bitbucket.org/mayastudios/cutetest/src",

--- a/diff-match-patch/diff-match-patch.2012-11-19.manifest
+++ b/diff-match-patch/diff-match-patch.2012-11-19.manifest
@@ -5,6 +5,9 @@
   "version": "20121119",
   "release_date": "2012-11-19",
   "summary": "Diff, Match and Patch libraries for Plain Text",
+  "topics": [
+    "Text"
+  ],
   "urls": {
     "homepage": "http://code.google.com/p/google-diff-match-patch/",
     "vcs": "http://code.google.com/p/google-diff-match-patch/source/browse/",

--- a/echonest/echonest.2013-05-16.manifest
+++ b/echonest/echonest.2013-05-16.manifest
@@ -4,6 +4,10 @@
   "release_date": "2013-05-16",
   "version": "2.1.0",
   "summary": "Qt library for communicating with The Echo Nest",
+  "topics": [
+    "Multimedia",
+    "API"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/libechonest",
     "api_docs": "http://pwsp.cleinias.com/libechonest_api/",

--- a/enginio-qt/enginio-qt.2013-07-02.manifest
+++ b/enginio-qt/enginio-qt.2013-07-02.manifest
@@ -4,6 +4,11 @@
   "release_date": "2013-07-02",
   "version": "0.5.0",
   "summary": "Enginio client library for Qt platfom. Provides both Qt C++ and QML APIs to client applications.",
+  "topics": [
+    "Data",
+    "API",
+    "QML"
+  ],
   "urls": {
     "homepage": "https://engin.io/",
     "vcs": "https://github.com/enginio/enginio-qt",

--- a/exaro/exaro.2009-08-27.manifest
+++ b/exaro/exaro.2009-08-27.manifest
@@ -4,6 +4,9 @@
   "version": "2.0.0",
   "release_date": "2009-08-27",
   "summary": "Report engine",
+  "topics": [
+    "Printing"
+  ],
   "urls": {
     "homepage": "http://exaro.sourceforge.net/",
     "vcs": "http://code.google.com/p/exaro/source/browse",

--- a/extra-cmake-modules/extra-cmake-modules.2016-06-13.manifest
+++ b/extra-cmake-modules/extra-cmake-modules.2016-06-13.manifest
@@ -4,6 +4,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Extensions for software using the CMake build system",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/kdesupport/extra-cmake-modules",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/ff7tk/ff7tk.manifest
+++ b/ff7tk/ff7tk.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "ff7tk",
   "summary": "Toolkit for working with data from Final Fantasy 7",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://forums.qhimm.com/index.php?topic=12938.msg184462",
     "vcs": "https://github.com/sithlord48/ff7tk/",

--- a/frameworkintegration/frameworkintegration.2016-06-13.manifest
+++ b/frameworkintegration/frameworkintegration.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Workspace and cross-framework integration plugins",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/frameworkintegration/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/gcf/gcf.2012-01-17.manifest
+++ b/gcf/gcf.2012-01-17.manifest
@@ -4,6 +4,9 @@
   "version": "2.6.0",
   "release_date": "2012-01-17",
   "summary": "Generic component framework",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://www.vcreatelogic.com/products/gcf",
     "vcs": "http://code.vcreatelogic.com:8045/GCF2/trunk/GCF",

--- a/glc-lib/glc-lib.2013-09-26.manifest
+++ b/glc-lib/glc-lib.2013-09-26.manifest
@@ -4,6 +4,9 @@
   "version": "2.5.2",
   "release_date": "2013-09-26",
   "summary": "Library for high performance 3D applications based on OpenGL",
+  "topics": [
+    "Graphics"
+  ],
   "urls": {
     "homepage": "http://www.glc-lib.net/",
     "vcs": "https://github.com/laumaya/GLC_lib",

--- a/injeqt/injeqt.2015-03-07.manifest
+++ b/injeqt/injeqt.2015-03-07.manifest
@@ -5,6 +5,9 @@
   "release_date": "2015-03-07",
   "version": "1.0.1",
   "summary": "Dependency injection",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "https://github.com/vogel/injeqt",
     "download": "https://github.com/vogel/injeqt/releases",

--- a/jreen/jreen.2013-01-07.manifest
+++ b/jreen/jreen.2013-01-07.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-01-07",
   "version": "1.1.1",
   "summary": "XMPP client library",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://qutim.org/jreen",
     "vcs": "https://github.com/euroelessar/jreen"

--- a/kactivities-stats/kactivities-stats.2016-06-13.manifest
+++ b/kactivities-stats/kactivities-stats.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "A library for accessing the usage data collected by the activities system.",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kactivities-stats/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kactivities/kactivities.2016-06-13.manifest
+++ b/kactivities/kactivities.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Runtime and library to organize the user work in separate activities",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kactivities/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/karchive/karchive.2016-06-13.manifest
+++ b/karchive/karchive.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "File compression",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/karchive/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kauth/kauth.2016-06-13.manifest
+++ b/kauth/kauth.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Abstraction to system policy and authentication features",
+  "topics": [
+    "Security",
+    "API"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kauth/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kbookmarks/kbookmarks.2016-06-13.manifest
+++ b/kbookmarks/kbookmarks.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Support for bookmarks and the XBEL format",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kbookmarks/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kcmutils/kcmutils.2016-06-13.manifest
+++ b/kcmutils/kcmutils.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Utilities for working with KCModules",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kcmutils/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kcodecs/kcodecs.2016-06-13.manifest
+++ b/kcodecs/kcodecs.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Text encoding",
+  "topics": [
+    "Text"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kcodecs/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kcompletion/kcompletion.2016-06-13.manifest
+++ b/kcompletion/kcompletion.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Text completion helpers and widgets",
+  "topics": [
+    "Text",
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kcompletion/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kconfig/kconfig.2016-06-13.manifest
+++ b/kconfig/kconfig.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Configuration system",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kconfig/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kconfigwidgets/kconfigwidgets.2016-06-13.manifest
+++ b/kconfigwidgets/kconfigwidgets.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Widgets for configuration dialogs",
+  "topics": [
+    "Development",
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kconfigwidgets/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kcoreaddons/kcoreaddons.2016-06-13.manifest
+++ b/kcoreaddons/kcoreaddons.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Addons to QtCore",
+  "topics": [
+    "Text",
+    "Data"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kcoreaddons/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kcrash/kcrash.2016-06-13.manifest
+++ b/kcrash/kcrash.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Support for application crash analysis and bug report from apps",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kcrash/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdbusaddons/kdbusaddons.2016-06-13.manifest
+++ b/kdbusaddons/kdbusaddons.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Addons to QtDBus",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kdbusaddons/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdchart/kdchart.manifest
+++ b/kdchart/kdchart.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "kdchart",
   "summary": "Creation of business charts",
+  "topics": [
+    "Graphics"
+  ],
   "urls": {
     "homepage": "http://www.kdab.com/kdab-products/kd-chart/",
     "api_docs": "http://docs.kdab.com/kdchart/latest/"

--- a/kdeclarative/kdeclarative.2016-06-13.manifest
+++ b/kdeclarative/kdeclarative.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Provides integration of QML and KDE Frameworks",
+  "topics": [
+    "Desktop",
+    "QML"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kdeclarative/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kded/kded.2016-06-13.manifest
+++ b/kded/kded.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Extensible deamon for providing system level services",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kded/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdelibs/kdelibs.2013-09-03.manifest
+++ b/kdelibs/kdelibs.2013-09-03.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-09-03",
   "version": "4.11.1",
   "summary": "KDE Development Platform",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://techbase.kde.org",
     "api_docs": "http://api.kde.org/4.11-api/kdelibs-apidocs/",

--- a/kdelibs4support/kdelibs4support.2016-06-13.manifest
+++ b/kdelibs4support/kdelibs4support.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Porting aid from KDELibs4",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kdelibs4support/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdepimlibs/kdepimlibs.2013-09-03.manifest
+++ b/kdepimlibs/kdepimlibs.2013-09-03.manifest
@@ -4,6 +4,10 @@
   "release_date": "2013-09-03",
   "version": "4.11.1",
   "summary": "KDE PIM Libraries",
+  "topics": [
+    "Data",
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://pim.kde.org",
     "api_docs": "http://api.kde.org/4.6-api/kdepimlibs-apidocs/",

--- a/kdesignerplugin/kdesignerplugin.2016-06-13.manifest
+++ b/kdesignerplugin/kdesignerplugin.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Integration of Frameworks widgets in Qt Designer/Creator",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kdesignerplugin/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdesu/kdesu.2016-06-13.manifest
+++ b/kdesu/kdesu.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Integration with su for elevated privileges",
+  "topics": [
+    "Security",
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kdesu/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdewebkit/kdewebkit.2016-06-13.manifest
+++ b/kdewebkit/kdewebkit.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "KDE Integration for QtWebKit",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kdewebkit/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdnssd/kdnssd.2016-06-13.manifest
+++ b/kdnssd/kdnssd.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Abstraction to system DNSSD features",
+  "topics": [
+    "Bindings",
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kdnssd/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdoctools/kdoctools.2016-06-13.manifest
+++ b/kdoctools/kdoctools.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Documentation generation from docbook",
+  "topics": [
+    "Development",
+    "Text"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kdoctools/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kdreports/kdreports.manifest
+++ b/kdreports/kdreports.manifest
@@ -3,6 +3,9 @@
   "name": "kdreports",
   "version": "1.5.0",
   "summary": "Report generator",
+  "topics": [
+    "Printing"
+  ],
   "urls": {
     "homepage": "http://www.kdab.com/kdab-products/kd-reports/",
     "api_docs": "http://docs.kdab.com/kdreports/1.5.0/",

--- a/kdsoap/kdsoap.2013-10-11.manifest
+++ b/kdsoap/kdsoap.2013-10-11.manifest
@@ -4,6 +4,10 @@
   "version": "1.3.0",
   "release_date": "2013-10-11",
   "summary": "Client-side and server-side SOAP component",
+  "topics": [
+    "API",
+    "Development"
+  ],
   "urls": {
     "vcs": "https://github.com/KDAB/KDSoap",
     "homepage": "http://www.kdab.com/kdab-products/kd-soap"

--- a/kdtools/kdtools.manifest
+++ b/kdtools/kdtools.manifest
@@ -2,6 +2,10 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "kdtools",
   "summary": "Productivity tools",
+  "topics": [
+    "Widgets",
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://www.kdab.com/kdab-products/kd-tools/"
   },

--- a/kemoticons/kemoticons.2016-06-13.manifest
+++ b/kemoticons/kemoticons.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Support for emoticons and emoticons themes",
+  "topics": [
+    "Artwork"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kemoticons/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kf5umbrella/kf5umbrella.2016-06-13.manifest
+++ b/kf5umbrella/kf5umbrella.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "CMake convenience functions for KDE Frameworks",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/frameworks/kf5umbrella",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kfileaudiopreview/kfileaudiopreview.2016-06-13.manifest
+++ b/kfileaudiopreview/kfileaudiopreview.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Preview of audio files",
+  "topics": [
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/frameworks/kfileaudiopreview",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kfilemetadata/kfilemetadata.2016-06-13.manifest
+++ b/kfilemetadata/kfilemetadata.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "A file metadata and text extraction library",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kfilemetadata/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kglobalaccel/kglobalaccel.2016-06-13.manifest
+++ b/kglobalaccel/kglobalaccel.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Add support for global workspace shortcuts",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kglobalaccel/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kguiaddons/kguiaddons.2016-06-13.manifest
+++ b/kguiaddons/kguiaddons.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Addons to QtGui",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kguiaddons/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/khtml/khtml.2016-06-13.manifest
+++ b/khtml/khtml.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "KHTML APIs",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/khtml/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/ki18n/ki18n.2016-06-13.manifest
+++ b/ki18n/ki18n.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Advanced internationalization framework",
+  "topics": [
+    "Development",
+    "Text"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/ki18n/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kiconthemes/kiconthemes.2016-06-13.manifest
+++ b/kiconthemes/kiconthemes.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Support for icon themes",
+  "topics": [
+    "Artwork"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kiconthemes/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kidletime/kidletime.2016-06-13.manifest
+++ b/kidletime/kidletime.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Monitoring user activity",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kidletime/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kimageformats/kimageformats.2016-06-13.manifest
+++ b/kimageformats/kimageformats.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Image format plugins for Qt",
+  "topics": [
+    "Graphics",
+    "Data"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kimageformats/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kinit/kinit.2016-06-13.manifest
+++ b/kinit/kinit.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Process launcher to speed up launching KDE applications",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kinit/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kio/kio.2016-06-13.manifest
+++ b/kio/kio.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Resource and network access abstraction",
+  "topics": [
+    "Communication",
+    "Data"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kio/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kitemmodels/kitemmodels.2016-06-13.manifest
+++ b/kitemmodels/kitemmodels.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Models for Qt Model/View system",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kitemmodels/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kitemviews/kitemviews.2016-06-13.manifest
+++ b/kitemviews/kitemviews.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Widget addons for Qt Model/View",
+  "topics": [
+    "Widgets",
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kitemviews/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kjobwidgets/kjobwidgets.2016-06-13.manifest
+++ b/kjobwidgets/kjobwidgets.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Widgets for tracking KJob instances",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kjobwidgets/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kjs/kjs.2016-06-13.manifest
+++ b/kjs/kjs.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Support for JS scripting in applications",
+  "topics": [
+    "Web",
+    "Scripting"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kjs/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kjsembed/kjsembed.2016-06-13.manifest
+++ b/kjsembed/kjsembed.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Embedded JS",
+  "topics": [
+    "Web",
+    "Scripting"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kjsembed/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/klfbackend/klfbackend.2013-06-23.manifest
+++ b/klfbackend/klfbackend.2013-06-23.manifest
@@ -4,6 +4,10 @@
   "release_date": "2013-06-23",
   "version": "3.2.7",
   "summary": "KLatexFormula backend library",
+  "topics": [
+    "Graphics",
+    "Data"
+  ],
   "urls": {
     "homepage": "http://klatexformula.sourceforge.net/",
     "api_docs": "http://klatexformula.sourceforge.net/doc/apidoc/klfbackend/html/",

--- a/kmediaplayer/kmediaplayer.2016-06-13.manifest
+++ b/kmediaplayer/kmediaplayer.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Plugin interface for media player features",
+  "topics": [
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kmediaplayer/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/knewstuff/knewstuff.2016-06-13.manifest
+++ b/knewstuff/knewstuff.2016-06-13.manifest
@@ -4,6 +4,10 @@
   "display_name": "KNewStuff",
   "release_date": "2016-06-13",
   "version": "5.23.0",
+  "topics": [
+    "Data",
+    "Communication"
+  ],
   "summary": "Support for downloading application assets from the network",
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/knewstuff/html/index.html",

--- a/knotifications/knotifications.2016-06-13.manifest
+++ b/knotifications/knotifications.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Abstraction for system notifications",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/knotifications/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/knotifyconfig/knotifyconfig.2016-06-13.manifest
+++ b/knotifyconfig/knotifyconfig.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Configuration system for KNotify",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/knotifyconfig/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kode/kode.manifest
+++ b/kode/kode.manifest
@@ -2,6 +2,10 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "kode",
   "summary": "Code generation library",
+  "topics": [
+    "Development",
+    "Data"
+  ],
   "urls": {
     "homepage": "http://www.lst.de/~cs/kode/",
     "vcs": "https://github.com/cornelius/kode/"

--- a/kpackage/kpackage.2016-06-13.manifest
+++ b/kpackage/kpackage.2016-06-13.manifest
@@ -4,6 +4,9 @@
   "display_name": "Package Framework",
   "release_date": "2016-06-13",
   "version": "5.23.0",
+  "topics": [
+    "Development"
+  ],
   "summary": "Library to load and install packages of non binary files as they were a plugin",
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kpackage/html/index.html",

--- a/kparts/kparts.2016-06-13.manifest
+++ b/kparts/kparts.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Document centric plugin system",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kparts/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kpeople/kpeople.2016-06-13.manifest
+++ b/kpeople/kpeople.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Provides access to all contacts and the people who hold them",
+  "topics": [
+    "Communication",
+    "Data"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kpeople/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kplotting/kplotting.2016-06-13.manifest
+++ b/kplotting/kplotting.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Lightweight plotting framework",
+  "topics": [
+    "Graphics"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kplotting/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kprintutils/kprintutils.2016-06-13.manifest
+++ b/kprintutils/kprintutils.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Print dialogs",
+  "topics": [
+    "Printing"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/frameworks/kprintutils",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kpty/kpty.2016-06-13.manifest
+++ b/kpty/kpty.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Pty abstraction",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kpty/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kqoauth/kqoauth.2013-09-08.manifest
+++ b/kqoauth/kqoauth.2013-09-08.manifest
@@ -5,6 +5,10 @@
   "version": "0.98",
   "display_name": "kQOAuth",
   "summary": "OAuth 1.0 authentication",
+  "topics": [
+    "Security",
+    "API"
+  ],
   "urls": {
     "homepage": "http://www.johanpaul.com/blog/kqoauth/",
     "vcs": "https://github.com/kypeli/kQOAuth"

--- a/kross/kross.2016-06-13.manifest
+++ b/kross/kross.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Multi-language application scripting",
+  "topics": [
+    "Scripting"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kross/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/krunner/krunner.2016-06-13.manifest
+++ b/krunner/krunner.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Parallelized query system",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/krunner/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kservice/kservice.2016-06-13.manifest
+++ b/kservice/kservice.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Advanced plugin and service introspection",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kservice/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/ktexteditor/ktexteditor.2016-06-13.manifest
+++ b/ktexteditor/ktexteditor.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Advanced embeddable text editor",
+  "topics": [
+    "Text",
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/ktexteditor/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/ktextwidgets/ktextwidgets.2016-06-13.manifest
+++ b/ktextwidgets/ktextwidgets.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Advanced text editing widgets",
+  "topics": [
+    "Text",
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/ktextwidgets/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kunitconversion/kunitconversion.2016-06-13.manifest
+++ b/kunitconversion/kunitconversion.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Support for unit conversion",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kunitconversion/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kwallet/kwallet.2016-06-13.manifest
+++ b/kwallet/kwallet.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Secure and unified container for user passwords",
+  "topics": [
+    "Security"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kwallet/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kwayland/kwayland.2015-09-08.manifest
+++ b/kwayland/kwayland.2015-09-08.manifest
@@ -5,6 +5,9 @@
   "release_date": "2015-09-08",
   "version": "5.4.1",
   "summary": "Qt-style API to interact with the wayland-client and wayland-server API",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/kde/workspace/kwayland",
     "api_docs": "http://kde.martin-graesslin.com/kwayland/",

--- a/kwidgetsaddons/kwidgetsaddons.2016-06-13.manifest
+++ b/kwidgetsaddons/kwidgetsaddons.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Addons to QtWidgets",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kwidgetsaddons/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kwindowsystem/kwindowsystem.2016-06-13.manifest
+++ b/kwindowsystem/kwindowsystem.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Access to the windowing system",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kwindowsystem/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kxmlgui/kxmlgui.2016-06-13.manifest
+++ b/kxmlgui/kxmlgui.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "User configurable main windows",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kxmlgui/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/kxmlrpcclient/kxmlrpcclient.2016-06-13.manifest
+++ b/kxmlrpcclient/kxmlrpcclient.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Interaction with XMLRPC services",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/kxmlrpcclient/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/libcommuni/libcommuni.2015-07-19.manifest
+++ b/libcommuni/libcommuni.2015-07-19.manifest
@@ -4,6 +4,9 @@
   "release_date": "2015-07-19",
   "version": "3.4.0",
   "summary": "IRC framework",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://communi.github.io",
     "api_docs": "http://communi.github.io/doc/",

--- a/libengsas/libengsas.2013-03-29.manifest
+++ b/libengsas/libengsas.2013-03-29.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-03-29",
   "version": "0.5.2",
   "summary": "Widgets for technical applications",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://www.engsas.de/libengsas",
     "vcs": "https://svn.engsas.de/libengsas",

--- a/libkexiv2/libkexiv2.2013-09-03.manifest
+++ b/libkexiv2/libkexiv2.2013-09-03.manifest
@@ -4,6 +4,10 @@
   "release_date": "2013-09-03",
   "version": "4.11.1",
   "summary": "Qt bindings for Exiv2, the library to manipulate picture meta data",
+  "topics": [
+    "Graphics",
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://www.digikam.org/sharedlibs",
     "api_docs": "http://api.kde.org/4.x-api/kdegraphics-apidocs/libs/libkexiv2/libkexiv2/html/index.html",

--- a/liblastfm/liblastfm.2013-09-03.manifest
+++ b/liblastfm/liblastfm.2013-09-03.manifest
@@ -4,6 +4,10 @@
   "release_date": "2013-09-03",
   "version": "1.0.8",
   "summary": "A Qt C++ library for the Last.fm webservices",
+  "topics": [
+    "API",
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "http://www.last.fm/download",
     "vcs": "https://github.com/lastfm/liblastfm"

--- a/libmm-qt/libmm-qt.2014-02-16.manifest
+++ b/libmm-qt/libmm-qt.2014-02-16.manifest
@@ -4,6 +4,10 @@
   "release_date": "2014-02-16",
   "version": "1.0.1",
   "summary": "Qt wrapper for ModemManager DBus API",
+  "topics": [
+    "Communication",
+    "Bindings"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/extragear/libs/libmm-qt",
     "vcs": "https://projects.kde.org/projects/extragear/libs/libmm-qt/repository"

--- a/libnm-qt/libnm-qt.2014-07-01.manifest
+++ b/libnm-qt/libnm-qt.2014-07-01.manifest
@@ -4,6 +4,10 @@
   "release_date": "2014-07-01",
   "version": "0.9.8.2",
   "summary": "Qt wrapper for NetworkManager DBus API",
+  "topics": [
+    "Communication",
+    "Bindings"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/extragear/libs/libnm-qt",
     "vcs": "https://projects.kde.org/projects/extragear/libs/libnm-qt/repository"

--- a/libqinfinity/libqinfinity.2013-09-22.manifest
+++ b/libqinfinity/libqinfinity.2013-09-22.manifest
@@ -4,6 +4,9 @@
   "version": "0.5.1",
   "release_date": "2013-09-22",
   "summary": "Qt wrapper around libinfinity, a library for collaborative editing",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/playground/libs/libqinfinity",
     "vcs": "https://projects.kde.org/projects/playground/libs/libqinfinity/repository"

--- a/libqtlua/libqtlua.2013-04-01.manifest
+++ b/libqtlua/libqtlua.2013-04-01.manifest
@@ -4,6 +4,9 @@
   "version": "2.0",
   "release_date": "2013-04-01",
   "summary": "Framework for embedding Lua in Qt applications",
+  "topics": [
+    "Scripting"
+  ],
   "urls": {
     "homepage": "http://www.nongnu.org/libqtlua/",
     "vcs": "http://svn.savannah.nongnu.org/viewvc/?root=libqtlua",

--- a/libqxt/libqxt.2011-11-24.manifest
+++ b/libqxt/libqxt.2011-11-24.manifest
@@ -4,6 +4,10 @@
   "version": "0.6.2",
   "release_date": "2011-11-24",
   "summary": "Utility classes for Qt",
+  "topics": [
+    "Development",
+    "Widgets"
+  ],
   "urls": {
     "homepage": "https://bitbucket.org/libqxt/libqxt/wiki/Home",
     "vcs": "http://dev.libqxt.org/libqxt/src"

--- a/libsystemd-qt/libsystemd-qt.2013-10-03.manifest
+++ b/libsystemd-qt/libsystemd-qt.2013-10-03.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-10-03",
   "version": "208",
   "summary": "Qt-only wrapper for the Systemd API",
+  "topics": [
+    "Bindings"
+  ],
   "urls": {
     "homepage": "https://github.com/andreascarpino/libsystemd-qt",
     "vcs": "https://github.com/andreascarpino/libsystemd-qt"

--- a/libtmdbqt/libtmdbqt.manifest
+++ b/libtmdbqt/libtmdbqt.manifest
@@ -3,6 +3,10 @@
   "name": "libtmdbqt",
   "display_name": "TmdbQt",
   "summary": "Library for querying The Movie Database API (themoviedb.org)",
+  "topics": [
+    "API",
+    "Data"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/playground/network/libtmdbqt",
     "vcs": "git clone git://anongit.kde.org/libtmdbqt"

--- a/limereport/limereport.2016-05-31.manifest
+++ b/limereport/limereport.2016-05-31.manifest
@@ -5,6 +5,9 @@
   "version": "1.3.11",
   "release_date": "2016-05-31",
   "summary": "Report printing engine",
+  "topics": [
+    "Printing"
+  ],
   "urls": {
     "homepage": "http://limereport.ru/",
     "vcs": "https://github.com/fralx/LimeReport",

--- a/log4qt-fork/log4qt-fork.2016-05-03.manifest
+++ b/log4qt-fork/log4qt-fork.2016-05-03.manifest
@@ -5,6 +5,10 @@
 	"release_date": "2016-05-03",
 	"version": "1.2.0",
 	"summary": "C++ port of the Log4j logging framework",
+	"topics": [
+	    "Development",
+	    "Logging"
+	],
 	"urls": {
 		"homepage": "https://github.com/MEONMedical/Log4Qt",
 		"vcs": "https://github.com/MEONMedical/Log4Qt.git",

--- a/log4qt/log4qt.2009-03-01.manifest
+++ b/log4qt/log4qt.2009-03-01.manifest
@@ -4,6 +4,10 @@
   "version": "0.3",
   "release_date": "2009-03-01",
   "summary": "C++ port of the Log4j logging framework",
+  "topics": [
+    "Development",
+    "Logging"
+  ],
   "urls": {
     "homepage": "http://log4qt.sourceforge.net/",
     "vcs": "http://sourceforge.net/p/log4qt/code/HEAD/tree/",

--- a/lxqt_wallet/lxqt_wallet.2015-10-04.manifest
+++ b/lxqt_wallet/lxqt_wallet.2015-10-04.manifest
@@ -4,6 +4,9 @@
   "release_date": "2015-10-04",
   "version": "2.2.0",
   "summary": "Secure storage of data in an internal storage system or in KDE KWallet or GNOME libsecret",
+  "topics": [
+    "Security"
+  ],
   "urls": {
     "homepage": "https://github.com/mhogomchungu/lxqt_wallet",
     "vcs": "https://github.com/mhogomchungu/lxqt_wallet.git",

--- a/marble/marble.2013-10-01.manifest
+++ b/marble/marble.2013-10-01.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-10-01",
   "version": "1.6.1",
   "summary": "Marble Virtual Globe",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://marble.kde.org",
     "api_docs": "http://api.kde.org/4.11-api/kdeedu-apidocs/marble/html/",

--- a/mimetypes-qt4/mimetypes-qt4.manifest
+++ b/mimetypes-qt4/mimetypes-qt4.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "mimetypes-qt4",
   "summary": "Backport of the Qt 5 mimetypes api to Qt 4",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://code.qt.io/cgit/playground/mimetypes.git/",
     "vcs": "http://code.qt.io/cgit/playground/mimetypes.git/"

--- a/modemmanager-qt/modemmanager-qt.2016-06-13.manifest
+++ b/modemmanager-qt/modemmanager-qt.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Qt wrapper for ModemManager API",
+  "topics": [
+    "Communication",
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/modemmanager-qt/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/ncreport/ncreport.manifest
+++ b/ncreport/ncreport.manifest
@@ -2,6 +2,10 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "ncreport",
   "summary": "Report generator",
+  "topics": [
+    "Printing",
+    "Data"
+  ],
   "urls": {
     "homepage": "http://www.nocisoft.com/ncreport.html"
   },

--- a/neiasound/neiasound.2016-06-13.manifest
+++ b/neiasound/neiasound.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "OpenAl wrapper for Qt apps and games",
+  "topics": [
+    "Multimedia",
+    "Bindings"
+  ],
   "urls": {
     "homepage": "https://github.com/lucaspcamargo/neiasound",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/networkmanager-qt/networkmanager-qt.2016-06-13.manifest
+++ b/networkmanager-qt/networkmanager-qt.2016-06-13.manifest
@@ -5,6 +5,10 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Qt wrapper for NetworkManager API",
+  "topics": [
+    "Communication",
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/networkmanager-qt/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/noron/noron.2015-11-30.manifest
+++ b/noron/noron.2015-11-30.manifest
@@ -5,6 +5,9 @@
   "version": "0.1",
   "release_date": "2015-11-30",
   "summary": "Remote object sharing",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "https://github.com/HamedMasafi/Noron",
     "download": "https://github.com/HamedMasafi/Noron"

--- a/novile/novile.2013-04-01.manifest
+++ b/novile/novile.2013-04-01.manifest
@@ -4,6 +4,10 @@
   "version": "0.5",
   "release_date": "2013-04-01",
   "summary": "Source code editor component for Qt",
+  "topics": [
+    "Development",
+    "Text"
+  ],
   "urls": {
     "homepage": "https://github.com/tucnak/novile",
     "vcs": "https://github.com/tucnak/novile",

--- a/nut/nut.2016-05-01.manifest
+++ b/nut/nut.2016-05-01.manifest
@@ -5,6 +5,9 @@
   "version": "0.1",
   "release_date": "2016-05-01",
   "summary": "Object relational mapper for Qt5",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "https://github.com/HamedMasafi/Nut",
     "download": "https://github.com/HamedMasafi/Nut",

--- a/o2/o2.2012-06-09.manifest
+++ b/o2/o2.2012-06-09.manifest
@@ -4,6 +4,10 @@
   "release_date": "2012-06-09",
   "version": "1.0",
   "summary": "A library encapsulating OAuth 1.0 and 2.0 client authentication flows",
+  "topics": [
+    "Security",
+    "Bindings"
+  ],
   "urls": {
     "homepage": "https://github.com/pipacs/o2",
     "api_docs": "https://github.com/pipacs/o2/blob/master/README.md",

--- a/osgqtquick/osgqtquick.2015-10-19.manifest
+++ b/osgqtquick/osgqtquick.2015-10-19.manifest
@@ -3,6 +3,10 @@
   "name": "osgqtquick",
   "display_name": "osgQtQuick",
   "summary": "OpenSceneGraph QML Modules",
+  "topics": [
+    "Graphics",
+    "QML"
+  ],
   "description": "Intergation OSG to Qt Quick",
   "version": "2.0.0-alpha-2",
   "maturity": "alpha",

--- a/oxygen-icons5/oxygen-icons5.2016-06-13.manifest
+++ b/oxygen-icons5/oxygen-icons5.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Oxygen icon theme",
+  "topics": [
+    "Artwork"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/oxygen-icons5/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/packagekit-qt/packagekit-qt.2013-05-08.manifest
+++ b/packagekit-qt/packagekit-qt.2013-05-08.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-05-08",
   "version": "0.8.8",
   "summary": "Qt bindings for PackageKit, the backend for managing software installation",
+  "topics": [
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://packagekit.org/",
     "vcs": "http://gitorious.org/packagekit/packagekit/trees/master/lib/packagekit-qt",

--- a/phonon/phonon.2011-12-19.manifest
+++ b/phonon/phonon.2011-12-19.manifest
@@ -4,6 +4,9 @@
   "release_date": "2011-12-19",
   "version": "4.6.0",
   "summary": "Phonon Multimedia Platform Abstraction",
+  "topics": [
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "http://phonon.kde.org/",
     "tutorial": "http://techbase.kde.org/Development/Tutorials/Phonon/Introduction",

--- a/plasma-framework/plasma-framework.2016-06-13.manifest
+++ b/plasma-framework/plasma-framework.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Plugin based UI runtime used to write primary user interfaces",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/plasma-framework/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/polkit-qt-1/polkit-qt-1.2011-12-15.manifest
+++ b/polkit-qt-1/polkit-qt-1.2011-12-15.manifest
@@ -4,6 +4,9 @@
   "release_date": "2011-12-15",
   "version": "0.103.0",
   "summary": "Qt bindings for PolicyKit",
+  "topics": [
+    "Bindings"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/kdesupport/polkit-qt-1",
     "vcs": "https://projects.kde.org/projects/kdesupport/polkit-qt-1/repository",

--- a/poppler-qt/poppler-qt.2013-08-26.manifest
+++ b/poppler-qt/poppler-qt.2013-08-26.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-08-26",
   "version": "0.24.1",
   "summary": "Qt bindings for Poppler, the PDF rendering library",
+  "topics": [
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://poppler.freedesktop.org/",
     "vcs": "http://cgit.freedesktop.org/poppler/poppler/tree/qt4",

--- a/pythonqt/pythonqt.2012-06-25.manifest
+++ b/pythonqt/pythonqt.2012-06-25.manifest
@@ -4,6 +4,9 @@
   "version": "2.1",
   "release_date": "2012-06-25",
   "summary": "Framework for embedding Python in Qt applications",
+  "topics": [
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://pythonqt.sourceforge.net/",
     "vcs": "http://sourceforge.net/p/pythonqt/code/HEAD/tree/"

--- a/q7goodies/q7goodies.manifest
+++ b/q7goodies/q7goodies.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "q7goodies",
   "summary": "Windows 7 taskbar extensions",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://www.strixcode.com/q7goodies/"
   },

--- a/qanmenubar/qanmenubar.2015-09-29.manifest
+++ b/qanmenubar/qanmenubar.2015-09-29.manifest
@@ -5,6 +5,9 @@
   "version": "0.0.4",
   "display_name": "QanMenuBar",
   "summary": "QanMenuBar is lightweight dynamic QML menu component similar to PieMenu",
+  "topics": [
+    "QML"
+  ],
   "urls": {
     "homepage": "http://www.qanava.org/qanava-menu/",
     "api_docs": "http://www.qanava.org/doc/qanmenu.html",

--- a/qaudiocoder/qaudiocoder.2012-07-20.manifest
+++ b/qaudiocoder/qaudiocoder.2012-07-20.manifest
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "release_date": "2012-07-20",
   "summary": "Library for audio decoding, encoding and audio file conversion",
+  "topics": [
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "http://qt-project.org/forums/viewthread/18960/",
     "vcs": "https://github.com/visore/QAudioCoder",

--- a/qca/qca.2010-11-27.manifest
+++ b/qca/qca.2010-11-27.manifest
@@ -4,6 +4,9 @@
   "release_date": "2010-11-27",
   "version": "2.0.3",
   "summary": "Qt Cryptographic Architecture",
+  "topics": [
+    "Security"
+  ],
   "urls": {
     "homepage": "http://delta.affinix.com/qca/",
     "vcs": "http://websvn.kde.org/trunk/kdesupport/qca/",

--- a/qcustomplot/qcustomplot.2015-12-22.manifest
+++ b/qcustomplot/qcustomplot.2015-12-22.manifest
@@ -5,6 +5,9 @@
   "version": "1.3.2",
   "release_date": "2015-12-22",
   "summary": "Plotting widget for Qt",
+  "topics": [
+    "Graphics"
+  ],
   "urls": {
     "homepage": "http://www.qcustomplot.com/index.php/introduction",
     "vcs": "https://gitlab.com/DerManu/QCustomPlot",

--- a/qdatacube/qdatacube.manifest
+++ b/qdatacube/qdatacube.manifest
@@ -2,6 +2,10 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qdatacube",
   "summary": "Datacube for Qt",
+  "topics": [
+    "Data",
+    "Widgets"
+  ],
   "urls": {
     "homepage": "https://gitlab.com/AngeOptimization/qdatacube",
     "vcs": "https://gitlab.com/AngeOptimization/qdatacube"

--- a/qdbf/qdbf.manifest
+++ b/qdbf/qdbf.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qdbf",
   "summary": "Library for handling dbf files",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "https://code.google.com/p/qdbf/",
     "vcs": "https://code.google.com/p/qdbf/source/browse/"

--- a/qdecimal/qdecimal.2012-09-03.manifest
+++ b/qdecimal/qdecimal.2012-09-03.manifest
@@ -5,6 +5,9 @@
   "version": "1.01",
   "release_date": "2012-09-03",
   "summary": "Decimal arithmetic library for Qt framework",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "https://code.google.com/p/qdecimal/",
     "vcs": "https://code.google.com/p/qdecimal/source/browse/"

--- a/qdjango/qdjango.2013-10-11.manifest
+++ b/qdjango/qdjango.2013-10-11.manifest
@@ -4,6 +4,9 @@
   "version": "0.4.0",
   "release_date": "2013-10-11",
   "summary": "ORM and HTTP request/response framework",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "https://code.google.com/p/qdjango/"
   },

--- a/qextserialport/qextserialport.2013-10-11.manifest
+++ b/qextserialport/qextserialport.2013-10-11.manifest
@@ -4,6 +4,9 @@
   "version": "1.2RC",
   "release_date": "2013-10-11",
   "summary": "Cross platform interface to serial ports.",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://code.google.com/p/qextserialport/"
   },

--- a/qfb/qfb.manifest
+++ b/qfb/qfb.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qfb",
   "summary": "Client library for accessing Facebook graph API",
+  "topics": [
+    "API"
+  ],
   "urls": {
     "homepage": "https://github.com/SfietKonstantin/qfb",
     "vcs": "https://github.com/SfietKonstantin/qfb"

--- a/qicstable/qicstable.manifest
+++ b/qicstable/qicstable.manifest
@@ -3,6 +3,10 @@
   "name": "qicstable",
   "display_name": "QicsTable",
   "summary": "High performance Qt table widget",
+  "topics": [
+    "Widgets",
+    "Data"
+  ],
   "urls": {
     "homepage": "https://gitorious.org/qicstable/",
     "download": "https://gitorious.org/qicstable/qicstable/"

--- a/qimageblitz/qimageblitz.2007-11-16.manifest
+++ b/qimageblitz/qimageblitz.2007-11-16.manifest
@@ -4,6 +4,9 @@
   "release_date": "2007-11-16",
   "version": "0.0.4",
   "summary": "Image Effect Library for KDE",
+  "topics": [
+    "Graphics"
+  ],
   "urls": {
     "homepage": "http://qimageblitz.sourceforge.net/",
     "api_docs": "http://api.kde.org/kdesupport-api/kdesupport-apidocs/qimageblitz/html/index.html",

--- a/qjson/qjson.2012-11-27.manifest
+++ b/qjson/qjson.2012-11-27.manifest
@@ -4,6 +4,9 @@
   "release_date": "2012-11-27",
   "version": "0.8.1",
   "summary": "JSON parser for Qt",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://qjson.sourceforge.net/",
     "api_docs": "http://qjson.sourceforge.net/docs/index.html",

--- a/qjsonrpc/qjsonrpc.manifest
+++ b/qjsonrpc/qjsonrpc.manifest
@@ -2,6 +2,10 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qjsonrpc",
   "summary": "Implementation of the JSON-RPC protocol",
+  "topics": [
+    "Data",
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://bitbucket.org/devonit/qjsonrpc",
     "vcs": "https://bitbucket.org/devonit/qjsonrpc/src"

--- a/qlogsystem/qlogsystem.2015-01-13.manifest
+++ b/qlogsystem/qlogsystem.2015-01-13.manifest
@@ -4,6 +4,10 @@
   "release_date": "2015-01-13",
   "version": "1.0.7",
   "summary": "qlogsystem is a very efficient and easy to use logger library",
+  "topics": [
+    "Development",
+    "Logging"
+  ],
   "urls": {
     "homepage": "https://github.com/balabit/qlogsystem",
     "vcs": "https://github.com/balabit/qlogsystem",

--- a/qoauth/qoauth.2010-08-01.manifest
+++ b/qoauth/qoauth.2010-08-01.manifest
@@ -4,6 +4,10 @@
   "release_date": "2010-08-01",
   "version": "1.0.1",
   "summary": "Library for OAuth authorization scheme",
+  "topics": [
+    "Security",
+    "API"
+  ],
   "urls": {
     "homepage": "http://github.com/ayoy/qoauth",
     "api_docs": "http://files.ayoy.net/qoauth/1.0.1/doc/",

--- a/qscintilla/qscintilla.2016-04-18.manifest
+++ b/qscintilla/qscintilla.2016-04-18.manifest
@@ -4,6 +4,9 @@
   "version": "2.9.2",
   "release_date": "2016-04-18",
   "summary": "Qt port of Scintilla C++ editor control",
+  "topics": [
+    "Text"
+  ],
   "urls": {
     "homepage": "https://riverbankcomputing.com/software/qscintilla/intro",
     "download": "https://riverbankcomputing.com/software/qscintilla/download",

--- a/qserialdevice/qserialdevice.manifest
+++ b/qserialdevice/qserialdevice.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qserialdevice",
   "summary": "Cross-platform library for accessing serial devices",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://gitorious.org/qserialdevice",
     "vcs": "https://gitorious.org/qserialdevice/qserialdevice"

--- a/qserialport/qserialport.2011-01-23.manifest
+++ b/qserialport/qserialport.2011-01-23.manifest
@@ -4,6 +4,9 @@
   "version": "0.1.1",
   "release_date": "2011-01-23",
   "summary": "Cross-platform serial port driver",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://sourceforge.net/projects/qserialport/",
     "vcs": "http://sourceforge.net/p/qserialport/code/HEAD/tree/"

--- a/qsint/qsint.manifest
+++ b/qsint/qsint.manifest
@@ -3,6 +3,9 @@
   "name": "qsint",
   "display_name": "QSint",
   "summary": "Open source Qt Widgets Collection",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://qt-apps.org/content/show.php?content=162296",
     "vcs": "http://sourceforge.net/p/qsint/code"

--- a/qslog/qslog.2013-05-30.manifest
+++ b/qslog/qslog.2013-05-30.manifest
@@ -4,6 +4,10 @@
   "version": "2.0b1",
   "release_date": "2013-05-30",
   "summary": "Simple Qt logger",
+  "topics": [
+    "Logging",
+    "Development"
+  ],
   "urls": {
     "homepage": "https://bitbucket.org/razvanpetru/qt-components/wiki/QsLog",
     "vcs": "https://bitbucket.org/razvanpetru/qt-components/src"

--- a/qsqlmigrator/qsqlmigrator.2013-10-09.manifest
+++ b/qsqlmigrator/qsqlmigrator.2013-10-09.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-10-09",
   "version": "1.0",
   "summary": "QSqlMigrator - keep track of your database migrations",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "https://github.com/hicknhack-software/QSqlMigrator",
     "vcs": "https://github.com/hicknhack-software/QSqlMigrator"

--- a/qt-certificate-addon/qt-certificate-addon.2013-02-17.manifest
+++ b/qt-certificate-addon/qt-certificate-addon.2013-02-17.manifest
@@ -4,6 +4,9 @@
   "version": "edge",
   "release_date": "2013-02-17",
   "summary": "Qt Certificate Addon",
+  "topics": [
+    "Security"
+  ],
   "urls": {
     "homepage": "http://xmelegance.org/devel/qt-certificate-addon/",
     "vcs": "https://gitorious.org/qt-certificate-addon"

--- a/qt-gstreamer/qt-gstreamer.2012-04-15.manifest
+++ b/qt-gstreamer/qt-gstreamer.2012-04-15.manifest
@@ -4,6 +4,10 @@
   "version": "0.10.2",
   "release_date": "2012-04-15",
   "summary": "Qt bindings for GStreamer",
+  "topics": [
+    "Bindings",
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "http://gstreamer.freedesktop.org/modules/qt-gstreamer.html",
     "vcs": "http://cgit.freedesktop.org/gstreamer/qt-gstreamer"

--- a/qtargparser/qtargparser.2016-01-25.manifest
+++ b/qtargparser/qtargparser.2016-01-25.manifest
@@ -4,6 +4,9 @@
   "version": "2.0.0",
   "release_date": "2016-01-25",
   "summary": "Command line parsing",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://igor-mironchik.besaba.com/projects/qtarg.php",
     "vcs": "https://github.com/igormironchik/qtargparser",

--- a/qtav/qtav.2016-03-02.manifest
+++ b/qtav/qtav.2016-03-02.manifest
@@ -4,6 +4,9 @@
   "release_date": "2016-03-02",
   "version": "1.10.0",
   "summary": "A cross-platform multimedia playback framework based on Qt and FFmpeg.",
+  "topics": [
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "http://www.qtav.org",
     "vcs": "https://github.com/wang-bin/QtAV",

--- a/qtdropbox/qtdropbox.2014-03-23.manifest
+++ b/qtdropbox/qtdropbox.2014-03-23.manifest
@@ -4,6 +4,9 @@
   "release_date": "2014-03-23",
   "version": "5.0",
   "summary": "Qt Dropbox",
+  "topics": [
+    "API"
+  ],
   "urls": {
     "homepage": "http://lycis.github.io/QtDropbox/",
     "vcs": "https://github.com/lycis/QtDropbox/"

--- a/qtermwidget/qtermwidget.2008-08-01.manifest
+++ b/qtermwidget/qtermwidget.2008-08-01.manifest
@@ -4,6 +4,9 @@
   "version": "0.1",
   "release_date": "2008-08-01",
   "summary": "Embeddable console widget",
+  "topics": [
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://qtermwidget.sourceforge.net/",
     "vcs": "http://qtermwidget.cvs.sourceforge.net/viewvc/qtermwidget/qtermwidget/",

--- a/qtffmpegwrapper/qtffmpegwrapper.2013-05-07.manifest
+++ b/qtffmpegwrapper/qtffmpegwrapper.2013-05-07.manifest
@@ -4,6 +4,9 @@
   "version": "20130507",
   "release_date": "2013-05-07",
   "summary": "Qt FFmpeg Wrapper for video frame encoding and decoding",
+  "topics": [
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "https://code.google.com/p/qtffmpegwrapper/",
     "vcs": "https://code.google.com/p/qtffmpegwrapper/source/browse/"

--- a/qtftp/qtftp.manifest
+++ b/qtftp/qtftp.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtftp",
   "summary": "FTP implementation",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://code.qt.io/cgit/qt/qtftp.git/",
     "vcs": "http://code.qt.io/cgit/qt/qtftp.git/"

--- a/qtgamepad/qtgamepad.manifest
+++ b/qtgamepad/qtgamepad.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtgamepad",
   "summary": "Reading input from gamepad devices",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://github.com/nezticle/qtgamepad",
     "vcs": "https://github.com/nezticle/qtgamepad"

--- a/qtgooglespeech/qtgooglespeech.manifest
+++ b/qtgooglespeech/qtgooglespeech.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtgooglespeech",
   "summary": "Library to use Google Speech service",
+  "topics": [
+    "API"
+  ],
   "urls": {
     "homepage": "https://github.com/niqt/QtGoogleSpeech",
     "vcs": "https://github.com/niqt/QtGoogleSpeech"

--- a/qthttp/qthttp.manifest
+++ b/qthttp/qthttp.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qthttp",
   "summary": "HTTP implementation",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://code.qt.io/cgit/qt/qthttp.git/",
     "vcs": "http://code.qt.io/cgit/qt/qthttp.git/"

--- a/qtilities/qtilities.2013-05-30.manifest
+++ b/qtilities/qtilities.2013-05-30.manifest
@@ -4,6 +4,10 @@
   "version": "1.4",
   "release_date": "2013-05-30",
   "summary": "Building blocks for Qt applications",
+  "topics": [
+    "Logging",
+    "Widgets"
+  ],
   "urls": {
     "homepage": "http://jpnaude.github.io/Qtilities/",
     "vcs": "https://github.com/JPNaude/Qtilities",

--- a/qtinstallerframework/qtinstallerframework.2013-10-14.manifest
+++ b/qtinstallerframework/qtinstallerframework.2013-10-14.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-10-14",
   "version": "1.4.0",
   "summary": "Tools and utilities to create installers for the supported desktop Qt platforms.",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://qt-project.org/doc/qtinstallerframework-1.4/index.html"
   },

--- a/qtioccontainer/qtioccontainer.2006-12-17.manifest
+++ b/qtioccontainer/qtioccontainer.2006-12-17.manifest
@@ -4,6 +4,9 @@
   "version": "3.5",
   "release_date": "2006-12-17",
   "summary": "Application framework inspired by Inversion Of Control concept",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://qtioccontainer.sourceforge.net/index.html",
     "vcs": "http://svn.sourceforge.net/qtioccontainer",

--- a/qtitanchart/qtitanchart.2013-05-03.manifest
+++ b/qtitanchart/qtitanchart.2013-05-03.manifest
@@ -4,6 +4,9 @@
   "version": "2.1",
   "release_date": "2013-05-03",
   "summary": "Generation of interactive diagrams",
+  "topics": [
+    "Graphics"
+  ],
   "urls": {
     "homepage": "http://www.devmachines.com/qtitanchart-overview.html"
   },

--- a/qtitanribbon/qtitanribbon.2013-08-26.manifest
+++ b/qtitanribbon/qtitanribbon.2013-08-26.manifest
@@ -4,6 +4,9 @@
   "version": "3.1",
   "release_date": "2013-08-26",
   "summary": "Components for ribbon-style user interfaces",
+  "topics": [
+    "Desktop"
+  ],
   "urls": {
     "homepage": "http://www.devmachines.com/qtitanribbon-overview.html"
   },

--- a/qtkeychain/qtkeychain.2014-09-01.manifest
+++ b/qtkeychain/qtkeychain.2014-09-01.manifest
@@ -4,6 +4,9 @@
   "release_date": "2014-09-01",
   "version": "0.4.0",
   "summary": "Platform-independent Qt API for storing passwords securely",
+  "topics": [
+    "Security"
+  ],
   "urls": {
     "homepage": "https://github.com/frankosterfeld/qtkeychain",
     "vcs": "https://github.com/frankosterfeld/qtkeychain"

--- a/qtmodeling/qtmodeling.manifest
+++ b/qtmodeling/qtmodeling.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtmodeling",
   "summary": "Framework for supporting model-driven engineering",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://wiki.qt.io/QtModeling",
     "vcs": "http://code.qt.io/cgit/qt/qtmodeling.git/"

--- a/qtoolbox/qtoolbox.manifest
+++ b/qtoolbox/qtoolbox.manifest
@@ -2,6 +2,10 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtoolbox",
   "summary": "Set of tools for Qt development",
+  "topics": [
+    "Data",
+    "Logging"
+  ],
   "urls": {
     "homepage": "https://github.com/detro/qtoolbox",
     "vcs": "https://github.com/detro/qtoolbox"

--- a/qtoptimization/qtoptimization.manifest
+++ b/qtoptimization/qtoptimization.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtoptimization",
   "summary": "Module for optimization algorithms",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "https://gitorious.org/qtoptimization",
     "vcs": "https://gitorious.org/qtoptimization/qtoptimization"

--- a/qtorm/qtorm.manifest
+++ b/qtorm/qtorm.manifest
@@ -2,6 +2,10 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtorm",
   "summary": "Object relational model inspired from Django",
+  "topics": [
+    "Web",
+    "Data"
+  ],
   "urls": {
     "homepage": "https://github.com/steckdenis/qtorm",
     "vcs": "https://github.com/steckdenis/qtorm.git"

--- a/qtrest/qtrest.manifest
+++ b/qtrest/qtrest.manifest
@@ -3,6 +3,10 @@
   "name": "qtrest",
   "display_name": "Qt REST Client",
   "summary": "Qt REST Client Framework for work JSON/XML APIs",
+  "topics": [
+    "Communication",
+    "API"
+  ],
   "urls": {
     "homepage": "https://github.com/kafeg/qtrest",
     "vcs": "https://github.com/kafeg/qtrest.git",

--- a/qtrpt/qtrpt.manifest
+++ b/qtrpt/qtrpt.manifest
@@ -3,6 +3,9 @@
   "name": "qtrpt",
   "display_name": "QtRPT",
   "summary": "Report engine",
+  "topics": [
+    "Printing"
+  ],
   "urls": {
     "homepage": "http://www.qtrpt.tk"
   },

--- a/qtsharp/qtsharp.2016-06-12.manifest
+++ b/qtsharp/qtsharp.2016-06-12.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-12",
   "version": "0.5.1",
   "summary": "Mono/.NET bindings for Qt",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "https://github.com/ddobrev/QtSharp",
     "vcs": "https://github.com/ddobrev/QtSharp",

--- a/qtspeech/qtspeech.manifest
+++ b/qtspeech/qtspeech.manifest
@@ -2,6 +2,10 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtspeech",
   "summary": "Cross-platform API to access and use system text-to-spech engines",
+  "topics": [
+    "Bindings",
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "http://lynxline.com/projects/qtspeech/",
     "vcs": "http://code.qt.io/cgit/qt/qtspeech.git/"

--- a/qtuio/qtuio.manifest
+++ b/qtuio/qtuio.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtuio",
   "summary": "Interface to TUIO, the protocol for tangible multi-touch surfaces",
+  "topics": [
+    "Mobile"
+  ],
   "urls": {
     "homepage": "http://qtuio.sirbabyface.net/",
     "vcs": "https://github.com/x29a/qTUIO"

--- a/qtuiotouch/qtuiotouch.manifest
+++ b/qtuiotouch/qtuiotouch.manifest
@@ -2,6 +2,9 @@
   "$schema": "http://inqlude.org/schema/generic-manifest-v1#",
   "name": "qtuiotouch",
   "summary": "Qt plugin for TUIO input devices",
+  "topics": [
+    "Mobile"
+  ],
   "urls": {
     "homepage": "https://github.com/dancasimiro/qtuiotouch",
     "vcs": "https://github.com/dancasimiro/qtuiotouch"

--- a/qtunits/qtunits.manifest
+++ b/qtunits/qtunits.manifest
@@ -3,6 +3,9 @@
   "name": "qtunits",
   "display_name": "QtUnits",
   "summary": "Qt runtime unit conversion library built using (and compatible with) Boost::Units.",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "https://github.com/hrobeers/QtUnits",
     "vcs": "https://github.com/hrobeers/QtUnits",

--- a/qtvkontakte/qtvkontakte.manifest
+++ b/qtvkontakte/qtvkontakte.manifest
@@ -3,6 +3,9 @@
   "name": "qtvkontakte",
   "display_name": "QtVkontakte",
   "summary": "Qt wrapper around Vkontakte Android SDK (https://vk.com, Russian social network)",
+  "topics": [
+    "Mobile"
+  ],
   "urls": {
     "homepage": "https://github.com/gilmanov-ildar/QtVkontakte",
     "vcs": "https://github.com/gilmanov-ildar/QtVkontakte.git",

--- a/qtwebapp/qtwebapp.2013-08-05.manifest
+++ b/qtwebapp/qtwebapp.2013-08-05.manifest
@@ -4,6 +4,9 @@
   "version": "1.3.1",
   "release_date": "2013-08-05",
   "summary": "Web application framework similar to Java Servlet API",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://stefanfrings.de/qtwebapp/index-en.html",
     "vcs": "",

--- a/qtwebkit/qtwebkit.2013-08-28.manifest
+++ b/qtwebkit/qtwebkit.2013-08-28.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-08-28",
   "version": "5.1.1",
   "summary": "Qt port of WebKit",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://trac.webkit.org/wiki/QtWebKit",
     "api_docs": "http://qt-project.org/doc/qt-5.1/qtwebkit/qtwebkit-index.html",

--- a/qtwebsockets/qtwebsockets.manifest
+++ b/qtwebsockets/qtwebsockets.manifest
@@ -3,6 +3,9 @@
   "name": "qtwebsockets",
   "display_name": "QtWebSockets",
   "summary": "Qt implementation of WebSockets client and server.",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://wiki.qt.io/QtWebSockets",
     "vcs": "http://code.qt.io/cgit/qt/qtwebsockets.git/"

--- a/qtweetlib/qtweetlib.2012-03-09.manifest
+++ b/qtweetlib/qtweetlib.2012-03-09.manifest
@@ -4,6 +4,9 @@
   "release_date": "2012-03-09",
   "version": "0.5",
   "summary": "Library to access Twitter",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://github.com/minimoog/QTweetLib",
     "download": "https://github.com/minimoog/QTweetLib/releases"

--- a/qtxlsx/qtxlsx.2014-01-20.manifest
+++ b/qtxlsx/qtxlsx.2014-01-20.manifest
@@ -5,6 +5,9 @@
   "version": "0.2.2",
   "release_date": "2014-01-20",
   "summary": ".xlsx file reader and writer for Qt5",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "https://github.com/dbzhang800/QtXlsxWriter",
     "api_docs": "http://qtxlsx.debao.me/"

--- a/quazip/quazip.2014-07-24.manifest
+++ b/quazip/quazip.2014-07-24.manifest
@@ -4,6 +4,9 @@
   "version": "0.7",
   "release_date": "2014-07-24",
   "summary": "Qt/C++ wrapper for ZIP/UNZIP package",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://quazip.sourceforge.net/",
     "vcs": "http://sourceforge.net/p/quazip/code/HEAD/tree/",

--- a/quickcross/quickcross.2016-01-07.manifest
+++ b/quickcross/quickcross.2016-01-07.manifest
@@ -3,6 +3,9 @@
   "name": "quickcross",
   "display_name": "Quick Cross",
   "summary": "QML Cross Platform Utility Library",
+  "topics": [
+    "QML"
+  ],
   "urls": {
     "homepage": "https://github.com/benlau/quickcross",
     "vcs": "https://github.com/benlau/quickcross",

--- a/quickflux/quickflux.2015-12-01.manifest
+++ b/quickflux/quickflux.2015-12-01.manifest
@@ -3,6 +3,9 @@
   "name": "quickflux",
   "display_name": "Quick Flux",
   "summary": "Message Dispatcher / Queue for Qt/QML",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://github.com/benlau/quickflux",
     "vcs": "https://github.com/benlau/quickflux",

--- a/quickpromise/quickpromise.2015-11-30.manifest
+++ b/quickpromise/quickpromise.2015-11-30.manifest
@@ -3,6 +3,9 @@
   "name": "quickpromise",
   "display_name": "Quick Promise",
   "summary": "QML Promise Library",
+  "topics": [
+    "QML"
+  ],
   "urls": {
     "homepage": "https://github.com/benlau/quickpromise",
     "vcs": "https://github.com/benlau/quickpromise.git",

--- a/quickproperties/quickproperties.2015-09-29.manifest
+++ b/quickproperties/quickproperties.2015-09-29.manifest
@@ -5,6 +5,9 @@
   "version": "0.0.4",
   "display_name": "QuickProperties",  
   "summary": "QuickProperties is a C++/QML library for viewving and editing QObject properties in Qt5",
+  "topics": [
+    "QML"
+  ],
   "urls": {
     "homepage": "http://www.qanava.org/quick-properties/",
     "api_docs": "http://www.qanava.org/doc/quickproperties.html",

--- a/quickqanava/quickqanava.2015-09-29.manifest
+++ b/quickqanava/quickqanava.2015-09-29.manifest
@@ -4,6 +4,10 @@
   "release_date": "2015-09-29",
   "version": "0.0.4",
   "summary": "QuickQanava",
+  "topics": [
+    "Graphics",
+    "QML"
+  ],
   "display_name": "QuickQanava is a C++/QML graph drawing library for Qt5",
   "urls": {
     "homepage": "http://www.qanava.org",

--- a/qwt/qwt.2013-05-30.manifest
+++ b/qwt/qwt.2013-05-30.manifest
@@ -4,6 +4,10 @@
   "release_date": "2013-05-30",
   "version": "6.1.0",
   "summary": "Widgets for Technical Applications",
+  "topics": [
+    "Widgets",
+    "Graphics"
+  ],
   "urls": {
     "homepage": "http://qwt.sourceforge.net/",
     "vcs": "http://qwt.svn.sourceforge.net/viewvc/qwt/",

--- a/qwtplot3d/qwtplot3d.2007-06-25.manifest
+++ b/qwtplot3d/qwtplot3d.2007-06-25.manifest
@@ -4,6 +4,9 @@
   "release_date": "2007-06-25",
   "version": "0.2.7",
   "summary": "3D plot widgets",
+  "topics": [
+    "Graphics"
+  ],
   "urls": {
     "homepage": "http://qwtplot3d.sourceforge.net/",
     "api_docs": "http://qwtplot3d.sourceforge.net/current/web/doxygen/hierarchy.html",

--- a/qxmpp/qxmpp.2014-03-26.manifest
+++ b/qxmpp/qxmpp.2014-03-26.manifest
@@ -4,6 +4,9 @@
   "release_date": "2014-03-26",
   "version": "0.8.0",
   "summary": "XMPP client and server library",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://github.com/qxmpp-project/qxmpp",
     "vcs": "https://github.com/qxmpp-project/qxmpp",

--- a/qxorm/qxorm.2013-10-11.manifest
+++ b/qxorm/qxorm.2013-10-11.manifest
@@ -4,6 +4,9 @@
   "version": "1.2.5",
   "release_date": "2013-10-11",
   "summary": "Qt-based Object Relational Mapping (ORM)",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://www.qxorm.com/qxorm_en/home.html"
   },

--- a/qyoto/qyoto.2013-09-03.manifest
+++ b/qyoto/qyoto.2013-09-03.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-09-03",
   "version": "4.11.1",
   "summary": "Mono bindings for core Qt libraries",
+  "topics": [
+    "Bindings"
+  ],
   "urls": {
     "homepage": "https://projects.kde.org/projects/kde/kdebindings/csharp/qyoto",
     "vcs": "https://projects.kde.org/projects/kde/kdebindings/csharp/qyoto/repository",

--- a/snorenotify/snorenotify.2016-01-11.manifest
+++ b/snorenotify/snorenotify.2016-01-11.manifest
@@ -4,6 +4,9 @@
   "release_date": "2016-01-11",
   "version": "0.7.0",
   "summary": "Snorenotify notification framework",
+  "topics": [
+    "Communication"
+  ],
   "urls": {
     "homepage": "https://techbase.kde.org/Projects/Snorenotify",
     "api_docs": "http://hannah.von-reth.de/snorenotify/doc/0.7.0/index.html",

--- a/solid/solid.2016-06-13.manifest
+++ b/solid/solid.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Hardware integration and detection",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/solid/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/sonnet/sonnet.2016-06-13.manifest
+++ b/sonnet/sonnet.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "Support for spellchecking",
+  "topics": [
+    "Text"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/sonnet/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/soprano/soprano.2013-07-10.manifest
+++ b/soprano/soprano.2013-07-10.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-07-10",
   "version": "2.9.3",
   "summary": "Qt/C++ RDF framework",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://soprano.sourceforge.net/",
     "download": "http://sourceforge.net/projects/soprano/files/Soprano/",

--- a/soqt/soqt.2010-03-03.manifest
+++ b/soqt/soqt.2010-03-03.manifest
@@ -4,6 +4,10 @@
   "release_date": "2010-03-03",
   "version": "1.5.0",
   "summary": "Qt interface for 3D visualization library Coin",
+  "topics": [
+    "Graphics",
+    "Bindings"
+  ],
   "urls": {
     "homepage": "http://www.coin3d.org/lib/soqt",
     "api_docs": "http://doc.coin3d.org/SoQt/"

--- a/sqlate/sqlate.2014-05-17.manifest
+++ b/sqlate/sqlate.2014-05-17.manifest
@@ -4,6 +4,9 @@
   "release_date": "2014-05-17",
   "version": "0.1.0",
   "summary": "type-safe template-based SQL support using Qt",
+  "topics": [
+    "Data"
+  ],
   "urls": {
     "homepage": "http://www.kdab.com/sqlate/",
     "vcs": "https://github.com/KDAB/sqlate/"

--- a/tasks/tasks.2015-12-26.manifest
+++ b/tasks/tasks.2015-12-26.manifest
@@ -4,6 +4,9 @@
   "release_date": "2015-12-26",
   "version": "1.2.1",
   "summary": "a simple single header library that allows async programming in Qt/C++ using tasks,continuations and resumable functions",
+  "topics": [
+    "Development"
+  ],
   "urls": {
 	  "homepage": "https://github.com/mhogomchungu/tasks",
 	  "vcs": "https://github.com/mhogomchungu/tasks.git",

--- a/telepathy-qt/telepathy-qt.2012-07-13.manifest
+++ b/telepathy-qt/telepathy-qt.2012-07-13.manifest
@@ -4,6 +4,10 @@
   "version": "0.9.3",
   "release_date": "2012-07-13",
   "summary": "Qt bindings for the Telepathy communications framework",
+  "topics": [
+    "Bindings",
+    "Communication"
+  ],
   "urls": {
     "homepage": "http://telepathy.freedesktop.org/wiki/",
     "vcs": "http://cgit.freedesktop.org/telepathy/telepathy-qt/",

--- a/threadweaver/threadweaver.2016-06-13.manifest
+++ b/threadweaver/threadweaver.2016-06-13.manifest
@@ -5,6 +5,9 @@
   "release_date": "2016-06-13",
   "version": "5.23.0",
   "summary": "High-level multithreading framework",
+  "topics": [
+    "Development"
+  ],
   "urls": {
     "homepage": "http://api.kde.org/frameworks-api/frameworks5-apidocs/threadweaver/html/index.html",
     "download": "http://download.kde.org/stable/frameworks/5.23/",

--- a/treefrog/treefrog.2013-09-17.manifest
+++ b/treefrog/treefrog.2013-09-17.manifest
@@ -4,6 +4,9 @@
   "version": "1.7.1",
   "release_date": "2013-09-17",
   "summary": "Framework for developing web applications",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://www.treefrogframework.org/",
     "vcs": "https://github.com/treefrogframework/treefrog-framework",

--- a/tufao/tufao.2013-06-30.manifest
+++ b/tufao/tufao.2013-06-30.manifest
@@ -4,6 +4,9 @@
   "release_date": "2013-06-30",
   "version": "1.0.2",
   "summary": "An asynchronous web framework for C++ built on top of Qt",
+  "topics": [
+    "Web"
+  ],
   "urls": {
     "homepage": "http://vinipsmaker.github.io/tufao/",
     "vcs": "https://github.com/vinipsmaker/tufao",

--- a/vlc-qt/vlc-qt.2015-12-27.manifest
+++ b/vlc-qt/vlc-qt.2015-12-27.manifest
@@ -5,6 +5,10 @@
   "release_date": "2015-12-27",
   "version": "1.0.0",
   "summary": "VLC-Qt - a simple library to connect Qt application with libVLC",
+  "topics": [
+    "Bindings",
+    "Multimedia"
+  ],
   "urls": {
     "homepage": "https://vlc-qt.tano.si",
     "download": "https://github.com/vlc-qt/vlc-qt/releases",


### PR DESCRIPTION
Use https://github.com/cornelius/inqlude/blob/master/topics/topics.csv as a base.
Topics are used to categorize libraries. Each library has one or more topics.