### PR TITLE
Correct display name and summary of QuickQanava

### DIFF
--- a/quickqanava/quickqanava.2015-09-29.manifest
+++ b/quickqanava/quickqanava.2015-09-29.manifest
@@ -3,8 +3,8 @@
   "name": "quickqanava",
   "release_date": "2015-09-29",
   "version": "0.0.4",
-  "summary": "QuickQanava",
-  "display_name": "QuickQanava is a C++/QML graph drawing library for Qt5",
+  "summary": "QuickQanava is a C++/QML graph drawing library for Qt5",
+  "display_name": "QuickQanava",
   "urls": {
     "homepage": "http://www.qanava.org",
     "api_docs": "http://www.qanava.org/doc/index.html",


### PR DESCRIPTION
Correct display name and summary of QuickQanava. They are interchanged at the moment.